### PR TITLE
feat: add cancel state, and method

### DIFF
--- a/contracts/multisig/ITimeLockedMultiSig.sol
+++ b/contracts/multisig/ITimeLockedMultiSig.sol
@@ -7,6 +7,7 @@ interface ITimeLockedMultisig {
         Unset,
         Waiting,
         Ready,
+        Cancelled,
         Done
     }
 
@@ -102,6 +103,11 @@ interface ITimeLockedMultisig {
      * @dev Returns whether an operation is done or not.
      */
     function isOperationDone(bytes32 id) external view returns (bool);
+
+    /**
+     * @dev Returns whether an operation is cancelled or not.
+     */
+    function isOperationCancelled(bytes32 id) external view returns (bool);
 
     /**
      * @dev Returns the timestamp at which an operation becomes ready (0 for

--- a/contracts/multisig/MultiSig.sol
+++ b/contracts/multisig/MultiSig.sol
@@ -157,6 +157,7 @@ contract MultiSig {
 
     function submitTransaction(
         address to,
+
         bytes memory data
     ) external payable onlyValidator {
         txCount++;


### PR DESCRIPTION
`solidity`의 `delete`는 `Nested Mapping`의 경우  모든 키를 지우는 것이 기술적으로 불가능하다.
```solidity
struct Operation {
    uint256 timestamps;
    mapping(address => bool) isApproved; // delete mapping[x]를 한다고 해서 이 부분이 삭제되지는 않는다.
}
```
그렇기 때문에 이미 `approve` 되었던것이 취소되었다가 재등록될 경우, 곧 바로 실행될수 있다.
그러므로 `delete` 대신 취소 상태를 따로 설정한다.


https://docs.soliditylang.org/en/develop/types.html#delete